### PR TITLE
Added eligibility checks for registering new users

### DIFF
--- a/app/components/main-button/main-button.presets.ts
+++ b/app/components/main-button/main-button.presets.ts
@@ -12,7 +12,6 @@ const BASE_VIEW: ViewStyle = {
   width: "70%",
   height: 60,
   position: "absolute",
-  top: "78%"
 }
 
 const BASE_TEXT: TextStyle = {
@@ -28,9 +27,7 @@ export const viewPresets: Record<string, ViewStyle> = {
   /**
    * A smaller piece of secondard information.
    */
-  primary: { ...BASE_VIEW,
-    backgroundColor: color.primaryDarker,
-  } as ViewStyle,
+  primary: { ...BASE_VIEW, backgroundColor: color.primaryDarker } as ViewStyle,
 
   /**
    * A button without extras.

--- a/app/screens/sponsors/sponsors-screen.tsx
+++ b/app/screens/sponsors/sponsors-screen.tsx
@@ -93,6 +93,7 @@ const CONTAINER: ViewStyle = {
   borderTopRightRadius: 40,
   borderTopLeftRadius: 40,
 }
+
 const SPONSORICON: ViewStyle = {
   flexDirection: "column",
   margin: 1,

--- a/eligibility.json
+++ b/eligibility.json
@@ -1,0 +1,2192 @@
+{
+    "Jpat756": {
+        "Timestamp": "27/02/2022 17:20:39",
+        "First Name": "Jayna",
+        "Last Name": "Patel",
+        "UPI": "Jpat756",
+        "Returning member? ": "Yes",
+        "Amount to pay": "0",
+        "Paid?": "N/A - Exec Member",
+        "App_Eligible": "y"
+    },
+    "vmia508": {
+        "Timestamp": "27/02/2022 17:33:27",
+        "First Name": "Vanessa",
+        "Last Name": "Miao",
+        "UPI": "vmia508",
+        "Returning member? ": "Yes",
+        "Amount to pay": "0",
+        "Paid?": "N/A - Exec Member",
+        "App_Eligible": "y"
+    },
+    "hkno470": {
+        "Timestamp": "27/02/2022 17:37:20",
+        "First Name": "Holly",
+        "Last Name": "Knowles",
+        "UPI": "hkno470",
+        "Returning member? ": "Yes",
+        "Amount to pay": "0",
+        "Paid?": "N/A - Exec Member",
+        "App_Eligible": "y"
+    },
+    "Csun325": {
+        "Timestamp": "27/02/2022 17:39:39",
+        "First Name": "Christine",
+        "Last Name": "Sun",
+        "UPI": "Csun325",
+        "Returning member? ": "Yes",
+        "Amount to pay": "0",
+        "Paid?": "N/A - Exec Member",
+        "App_Eligible": "y"
+    },
+    "fcha372": {
+        "Timestamp": "27/02/2022 18:24:53",
+        "First Name": "Cindy",
+        "Last Name": "Chang",
+        "UPI": "fcha372",
+        "Returning member? ": "Yes",
+        "Amount to pay": "0",
+        "Paid?": "N/A - Exec Member",
+        "App_Eligible": "y"
+    },
+    "zali162 ": {
+        "Timestamp": "28/02/2022 10:38:29",
+        "First Name": "Zeenat",
+        "Last Name": "Ali",
+        "UPI": "zali162 ",
+        "Returning member? ": "Yes",
+        "Amount to pay": "0",
+        "Paid?": "N/A - Exec Member",
+        "App_Eligible": "y"
+    },
+    "dpri537": {
+        "Timestamp": "28/02/2022 11:21:42",
+        "First Name": "Danielle",
+        "Last Name": "Print",
+        "UPI": "dpri537",
+        "Returning member? ": "Yes",
+        "Amount to pay": "0",
+        "Paid?": "N/A - Exec Member",
+        "App_Eligible": "y"
+    },
+    "npar276": {
+        "Timestamp": "28/02/2022 11:49:33",
+        "First Name": "Stephen",
+        "Last Name": "Parinas",
+        "UPI": "npar276",
+        "Returning member? ": "Yes",
+        "Amount to pay": "0",
+        "Paid?": "N/A - Exec Member",
+        "App_Eligible": "y"
+    },
+    "bkno906": {
+        "Timestamp": "28/02/2022 11:57:46",
+        "First Name": "Brooke",
+        "Last Name": "Knowles",
+        "UPI": "bkno906",
+        "Returning member? ": "Yes",
+        "Amount to pay": "0",
+        "Paid?": "N/A - Exec Member",
+        "App_Eligible": "y"
+    },
+    "lshe702": {
+        "Timestamp": "28/02/2022 15:40:07",
+        "First Name": "Laura",
+        "Last Name": "Shekouh",
+        "UPI": "lshe702",
+        "Returning member? ": "Yes",
+        "Amount to pay": "0",
+        "Paid?": "N/A - Exec Member",
+        "App_Eligible": "y"
+    },
+    "Skal343": {
+        "Timestamp": "28/02/2022 21:37:15",
+        "First Name": "Saba ",
+        "Last Name": "Kalyan",
+        "UPI": "Skal343",
+        "Returning member? ": "No",
+        "Amount to pay": "0",
+        "Paid?": "N/A - Exec Member",
+        "App_Eligible": "y"
+    },
+    "wpan224": {
+        "Timestamp": "01/03/2022 18:31:26",
+        "First Name": "Winnie",
+        "Last Name": "Pan",
+        "UPI": "wpan224",
+        "Returning member? ": "Yes",
+        "Amount to pay": "0",
+        "Paid?": "N/A - Exec Member",
+        "App_Eligible": "y"
+    },
+    "vobe810": {
+        "Timestamp": "01/03/2022 18:38:01",
+        "First Name": "Viresh",
+        "Last Name": "Oberoi",
+        "UPI": "vobe810",
+        "Returning member? ": "Yes",
+        "Amount to pay": "0",
+        "Paid?": "N/A - Exec Member",
+        "App_Eligible": "y"
+    },
+    "kcok691": {
+        "Timestamp": "24/03/2022 20:21:32",
+        "First Name": "Kelly",
+        "Last Name": "Cokorudy",
+        "UPI": "kcok691",
+        "Returning member? ": "Yes",
+        "Amount to pay": "0",
+        "Paid?": "N/A - Exec Member",
+        "App_Eligible": "y"
+    },
+    "xzha897": {
+        "Timestamp": "28/02/2022 19:05:04",
+        "First Name": "Raymond",
+        "Last Name": "Zhang",
+        "UPI": "xzha897",
+        "Returning member? ": "Yes",
+        "Amount to pay": "0",
+        "Paid?": "N/A - Pub Quiz Winner",
+        "App_Eligible": "y"
+    },
+    "vli763": {
+        "Timestamp": "28/02/2022 20:53:56",
+        "First Name": "Vicky",
+        "Last Name": "Li",
+        "UPI": "vli763",
+        "Returning member? ": "No",
+        "Amount to pay": "0",
+        "Paid?": "N/A - Pub Quiz Winner",
+        "App_Eligible": "y"
+    },
+    "lnga158": {
+        "Timestamp": "01/03/2022 12:51:03",
+        "First Name": "logan",
+        "Last Name": "ngan",
+        "UPI": "lnga158",
+        "Returning member? ": "No",
+        "Amount to pay": "0",
+        "Paid?": "N/A - Pub Quiz Winner",
+        "App_Eligible": "y"
+    },
+    "Kdin073": {
+        "Timestamp": "02/03/2022 10:07:19",
+        "First Name": "Kelly",
+        "Last Name": "Ding",
+        "UPI": "Kdin073",
+        "Returning member? ": "Yes",
+        "Amount to pay": "0",
+        "Paid?": "N/A - Pub Quiz Winner",
+        "App_Eligible": "y"
+    },
+    "cdal842": {
+        "Timestamp": "27/02/2022 17:02:45",
+        "First Name": "Chantal",
+        "Last Name": "Dalebroux",
+        "UPI": "cdal842",
+        "Returning member? ": "Yes",
+        "Amount to pay": "5",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "Jfen477 ": {
+        "Timestamp": "27/02/2022 17:49:49",
+        "First Name": "Jessica",
+        "Last Name": "Fenwick ",
+        "UPI": "Jfen477 ",
+        "Returning member? ": "Yes",
+        "Amount to pay": "5",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "Mbel541": {
+        "Timestamp": "27/02/2022 22:55:08",
+        "First Name": "Mila",
+        "Last Name": "Beldon",
+        "UPI": "Mbel541",
+        "Returning member? ": "Yes",
+        "Amount to pay": "5",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "hqiu657": {
+        "Timestamp": "28/02/2022 10:14:10",
+        "First Name": "Henry",
+        "Last Name": "Qiu",
+        "UPI": "hqiu657",
+        "Returning member? ": "Yes",
+        "Amount to pay": "5",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "jkuz831": {
+        "Timestamp": "28/02/2022 11:44:43",
+        "First Name": "Jenice",
+        "Last Name": "Kuzhikombil",
+        "UPI": "jkuz831",
+        "Returning member? ": "Yes",
+        "Amount to pay": "5",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "cpri703": {
+        "Timestamp": "28/02/2022 11:47:43",
+        "First Name": "Charlotte",
+        "Last Name": "Print",
+        "UPI": "cpri703",
+        "Returning member? ": "Yes",
+        "Amount to pay": "5",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "jsha485": {
+        "Timestamp": "28/02/2022 12:53:45",
+        "First Name": "Julia",
+        "Last Name": "Shan",
+        "UPI": "jsha485",
+        "Returning member? ": "Yes",
+        "Amount to pay": "5",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "alum819": {
+        "Timestamp": "28/02/2022 14:05:37",
+        "First Name": "Ashleigh",
+        "Last Name": "Lum",
+        "UPI": "alum819",
+        "Returning member? ": "Yes",
+        "Amount to pay": "5",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "ybat666": {
+        "Timestamp": "28/02/2022 17:27:18",
+        "First Name": "Yasara",
+        "Last Name": "Batawala",
+        "UPI": "ybat666",
+        "Returning member? ": "Yes",
+        "Amount to pay": "5",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "msin812": {
+        "Timestamp": "28/02/2022 18:40:13",
+        "First Name": "Maneet",
+        "Last Name": "Singh",
+        "UPI": "msin812",
+        "Returning member? ": "Yes",
+        "Amount to pay": "5",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "ymen072": {
+        "Timestamp": "01/03/2022 12:05:46",
+        "First Name": "Helen",
+        "Last Name": "Meng",
+        "UPI": "ymen072",
+        "Returning member? ": "Yes",
+        "Amount to pay": "5",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "mash446": {
+        "Timestamp": "02/03/2022 09:46:26",
+        "First Name": "Michael",
+        "Last Name": "Ashton",
+        "UPI": "mash446",
+        "Returning member? ": "Yes",
+        "Amount to pay": "5",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "jmil874": {
+        "Timestamp": "28/03/2022 20:21:32",
+        "First Name": "Jordyn",
+        "Last Name": "Millward",
+        "UPI": "jmil874",
+        "Returning member? ": "Yes",
+        "Amount to pay": "5",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "Ttrk819": {
+        "Timestamp": "09/04/2022 20:21:32",
+        "First Name": "Tsai",
+        "Last Name": "Te Kapaiwaho ",
+        "UPI": "Ttrk819",
+        "Returning member? ": "Yes",
+        "Amount to pay": "5",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "asin421": {
+        "Timestamp": "16/04/2022 20:21:32",
+        "First Name": "Adarsh",
+        "Last Name": "Singh",
+        "UPI": "asin421",
+        "Returning member? ": "Yes",
+        "Amount to pay": "5",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "Schb832 ": {
+        "Timestamp": "22/03/2022 17:53:10",
+        "First Name": "Simran ",
+        "Last Name": "Chandradevan ",
+        "UPI": "Schb832 ",
+        "Returning member? ": "Yes",
+        "Amount to pay": "5",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "sisn213": {
+        "Timestamp": "22/03/2022 18:04:42",
+        "First Name": "Shaleen",
+        "Last Name": "Singh-Ark",
+        "UPI": "sisn213",
+        "Returning member? ": "Yes",
+        "Amount to pay": "5",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "heve126": {
+        "Timestamp": "22/03/2022 18:04:42",
+        "First Name": "Hannah",
+        "Last Name": "Everett",
+        "UPI": "heve126",
+        "Returning member? ": "Yes",
+        "Amount to pay": "5",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "Jgre579": {
+        "Timestamp": "08/04/2022 14:25:20",
+        "First Name": "Jordan",
+        "Last Name": "Green",
+        "UPI": "Jgre579",
+        "Returning member? ": "Yes",
+        "Amount to pay": "5",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "cdak978": {
+        "Timestamp": "08/04/2022 14:25:30",
+        "First Name": "Chloe",
+        "Last Name": "Daken",
+        "UPI": "cdak978",
+        "Returning member? ": "Yes",
+        "Amount to pay": "5",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "ssri456": {
+        "Timestamp": "01/03/2022 14:24:36",
+        "First Name": "Shreya",
+        "Last Name": "Sriram",
+        "UPI": "ssri456",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "No",
+        "App_Eligible": "n"
+    },
+    "mman136": {
+        "Timestamp": "01/03/2022 20:18:16",
+        "First Name": "Leta",
+        "Last Name": "Manumalealii",
+        "UPI": "mman136",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "No",
+        "App_Eligible": "n"
+    },
+    "aara647": {
+        "Timestamp": "01/03/2022 21:02:49",
+        "First Name": "Antonio",
+        "Last Name": "Aranyos",
+        "UPI": "aara647",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "No",
+        "App_Eligible": "n"
+    },
+    "jsun184": {
+        "Timestamp": "01/03/2022 21:24:54",
+        "First Name": "Amber Jia Ye ",
+        "Last Name": "Sun",
+        "UPI": "jsun184",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "No",
+        "App_Eligible": "n"
+    },
+    "tvon705": {
+        "Timestamp": "01/03/2022 22:03:10",
+        "First Name": "Trinity",
+        "Last Name": "Vong",
+        "UPI": "tvon705",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "No",
+        "App_Eligible": "n"
+    },
+    "bgap484": {
+        "Timestamp": "03/03/2022 10:39:02",
+        "First Name": "Brooke",
+        "Last Name": "Gapes",
+        "UPI": "bgap484",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "No",
+        "App_Eligible": "n"
+    },
+    "kyan833": {
+        "Timestamp": "03/03/2022 13:57:25",
+        "First Name": "Dawn",
+        "Last Name": "Yang",
+        "UPI": "kyan833",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "No",
+        "App_Eligible": "n"
+    },
+    "swan250": {
+        "Timestamp": "03/03/2022 14:05:40",
+        "First Name": "Betty",
+        "Last Name": "wang",
+        "UPI": "swan250",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "No",
+        "App_Eligible": "n"
+    },
+    "apat256": {
+        "Timestamp": "03/03/2022 15:24:15",
+        "First Name": "Alisha",
+        "Last Name": "Patel",
+        "UPI": "apat256",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "No",
+        "App_Eligible": "n"
+    },
+    "02-0272-0210503-000": {
+        "Timestamp": "17/03/2022 15:29:02",
+        "First Name": "Alex",
+        "Last Name": "Smith",
+        "UPI": "02-0272-0210503-000",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "No",
+        "App_Eligible": "n"
+    },
+    "lbou222": {
+        "Timestamp": "20/03/2022 20:21:32",
+        "First Name": "Lola",
+        "Last Name": "Vahey Bourne",
+        "UPI": "lbou222",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "No",
+        "App_Eligible": "n"
+    },
+    "dkap847": {
+        "Timestamp": "07/04/2022 20:21:32",
+        "First Name": "Dhvani",
+        "Last Name": "Kapadia",
+        "UPI": "dkap847",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "No",
+        "App_Eligible": "n"
+    },
+    "ttan162": {
+        "Timestamp": "13/04/2022 20:21:32",
+        "First Name": "Gene",
+        "Last Name": "Tang",
+        "UPI": "ttan162",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "No",
+        "App_Eligible": "n"
+    },
+    "skan543": {
+        "Timestamp": "15/04/2022 20:21:32",
+        "First Name": "Sam",
+        "Last Name": "Kang",
+        "UPI": "skan543",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "No",
+        "App_Eligible": "n"
+    },
+    "kcol522": {
+        "Timestamp": "18/04/2022 20:21:32",
+        "First Name": "Kevin",
+        "Last Name": "Colita",
+        "UPI": "kcol522",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "No",
+        "App_Eligible": "n"
+    },
+    "csan863": {
+        "Timestamp": "19/04/2022 20:21:32",
+        "First Name": "Caroline",
+        "Last Name": "Santosa",
+        "UPI": "csan863",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "No",
+        "App_Eligible": "n"
+    },
+    "atao066": {
+        "Timestamp": "24/03/2022 17:25:18",
+        "First Name": "Astarlii",
+        "Last Name": "Taokia",
+        "UPI": "atao066",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "No",
+        "App_Eligible": "n"
+    },
+    "znab111": {
+        "Timestamp": "27/03/2022 16:43:19",
+        "First Name": "Zaakirah",
+        "Last Name": "Nabi",
+        "UPI": "znab111",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "No",
+        "App_Eligible": "n"
+    },
+    "cwhi149": {
+        "Timestamp": "03/04/2022 12:01:40",
+        "First Name": "Caitlin",
+        "Last Name": "Whiteman",
+        "UPI": "cwhi149",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "No",
+        "App_Eligible": "n"
+    },
+    "haun709": {
+        "Timestamp": "06/04/2022 17:43:42",
+        "First Name": "Hazel",
+        "Last Name": "Aung",
+        "UPI": "haun709",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "No",
+        "App_Eligible": "n"
+    },
+    "spor288": {
+        "Timestamp": "14/04/2022 14:46:18",
+        "First Name": "Stella",
+        "Last Name": "Portass",
+        "UPI": "spor288",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "No",
+        "App_Eligible": "n"
+    },
+    "ngan241": {
+        "Timestamp": "03/03/2022 16:39:42",
+        "First Name": "Natalie ",
+        "Last Name": "Gane ",
+        "UPI": "ngan241",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "No (but said they have)",
+        "App_Eligible": "n"
+    },
+    "hper164": {
+        "Timestamp": "17/03/2022 20:21:32",
+        "First Name": "Hirushi",
+        "Last Name": "Perera",
+        "UPI": "hper164",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "No (but said they have)",
+        "App_Eligible": "n"
+    },
+    "Rtow291": {
+        "Timestamp": "23/04/2022 20:21:32",
+        "First Name": "Ryan ",
+        "Last Name": "Townsend",
+        "UPI": "Rtow291",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "No (but said they have)",
+        "App_Eligible": "n"
+    },
+    "slan432": {
+        "Timestamp": "27/02/2022 16:49:29",
+        "First Name": "Sankalp",
+        "Last Name": "Lanka",
+        "UPI": "slan432",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "nlee982": {
+        "Timestamp": "27/02/2022 17:04:30",
+        "First Name": "Nadia",
+        "Last Name": "Lee",
+        "UPI": "nlee982",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "cosa267": {
+        "Timestamp": "28/02/2022 00:25:37",
+        "First Name": "Caitlin",
+        "Last Name": "Osa",
+        "UPI": "cosa267",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "qlao105": {
+        "Timestamp": "28/02/2022 10:12:43",
+        "First Name": "Qoobie",
+        "Last Name": "Lao",
+        "UPI": "qlao105",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "slin721": {
+        "Timestamp": "28/02/2022 10:50:17",
+        "First Name": "Sonia",
+        "Last Name": "Lin",
+        "UPI": "slin721",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "abar494": {
+        "Timestamp": "28/02/2022 11:16:23",
+        "First Name": "Ahmad",
+        "Last Name": "Barzak",
+        "UPI": "abar494",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "mzho226": {
+        "Timestamp": "28/02/2022 11:26:20",
+        "First Name": "Maggie",
+        "Last Name": "Zhou",
+        "UPI": "mzho226",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "aahk568": {
+        "Timestamp": "28/02/2022 12:37:04",
+        "First Name": "Ari ",
+        "Last Name": "Khan",
+        "UPI": "aahk568",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "iris540": {
+        "Timestamp": "28/02/2022 12:38:09",
+        "First Name": "Isobel",
+        "Last Name": "Rist",
+        "UPI": "iris540",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "mask067": {
+        "Timestamp": "28/02/2022 13:01:11",
+        "First Name": "mira",
+        "Last Name": "askari",
+        "UPI": "mask067",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "jnon847": {
+        "Timestamp": "28/02/2022 13:16:40",
+        "First Name": "Jackie",
+        "Last Name": "Nong",
+        "UPI": "jnon847",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "esio215": {
+        "Timestamp": "28/02/2022 13:22:09",
+        "First Name": "Emma",
+        "Last Name": "Sio",
+        "UPI": "esio215",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "apra923": {
+        "Timestamp": "28/02/2022 13:30:25",
+        "First Name": "Anya",
+        "Last Name": "Prakash",
+        "UPI": "apra923",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "Jkle094": {
+        "Timestamp": "28/02/2022 13:32:19",
+        "First Name": "Jeremy",
+        "Last Name": "Kleine",
+        "UPI": "Jkle094",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "ybeh516": {
+        "Timestamp": "28/02/2022 14:02:05",
+        "First Name": "Yuvraj",
+        "Last Name": "Behal",
+        "UPI": "ybeh516",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "nbab251": {
+        "Timestamp": "28/02/2022 14:06:49",
+        "First Name": "Nikilesh",
+        "Last Name": "Babu",
+        "UPI": "nbab251",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "Amos697": {
+        "Timestamp": "28/02/2022 14:08:11",
+        "First Name": "Abby",
+        "Last Name": "Moses",
+        "UPI": "Amos697",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "sahn558": {
+        "Timestamp": "28/02/2022 14:19:55",
+        "First Name": "Harry",
+        "Last Name": "Ahn",
+        "UPI": "sahn558",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "etho311": {
+        "Timestamp": "28/02/2022 15:11:45",
+        "First Name": "Beth",
+        "Last Name": "Thomson",
+        "UPI": "etho311",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "lcha691": {
+        "Timestamp": "28/02/2022 16:13:36",
+        "First Name": "Lachlan",
+        "Last Name": "Chan",
+        "UPI": "lcha691",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "weat986": {
+        "Timestamp": "28/02/2022 16:13:45",
+        "First Name": "William",
+        "Last Name": "Eaton",
+        "UPI": "weat986",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "rthu365": {
+        "Timestamp": "28/02/2022 16:18:35",
+        "First Name": "Riya ",
+        "Last Name": "Thumma ",
+        "UPI": "rthu365",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "rana423": {
+        "Timestamp": "28/02/2022 16:29:41",
+        "First Name": "rosa ",
+        "Last Name": "anahita",
+        "UPI": "rana423",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "kraj833": {
+        "Timestamp": "28/02/2022 16:30:40",
+        "First Name": "Kirti",
+        "Last Name": "Raju",
+        "UPI": "kraj833",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "balt638": {
+        "Timestamp": "28/02/2022 16:50:10",
+        "First Name": "Blaithan",
+        "Last Name": "Altenburg",
+        "UPI": "balt638",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "acmu767": {
+        "Timestamp": "28/02/2022 17:07:28",
+        "First Name": "Ashni",
+        "Last Name": "Sundar",
+        "UPI": "acmu767",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "gker710": {
+        "Timestamp": "28/02/2022 17:11:26",
+        "First Name": "Grace",
+        "Last Name": "Kerr",
+        "UPI": "gker710",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "mgad228": {
+        "Timestamp": "28/02/2022 17:15:16",
+        "First Name": "Meghana",
+        "Last Name": "Gaddam",
+        "UPI": "mgad228",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "cmal780": {
+        "Timestamp": "28/02/2022 17:18:48",
+        "First Name": "Cody",
+        "Last Name": "Malaki",
+        "UPI": "cmal780",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "kwan650": {
+        "Timestamp": "28/02/2022 17:23:57",
+        "First Name": "Josh",
+        "Last Name": "Wang",
+        "UPI": "kwan650",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "gmcs515": {
+        "Timestamp": "28/02/2022 17:26:22",
+        "First Name": "Grace",
+        "Last Name": "McSweeney",
+        "UPI": "gmcs515",
+        "Returning member? ": "Yes",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "lleu503": {
+        "Timestamp": "28/02/2022 17:29:22",
+        "First Name": "Ava",
+        "Last Name": "Leung ",
+        "UPI": "lleu503",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "pcam471": {
+        "Timestamp": "28/02/2022 17:33:37",
+        "First Name": "Paige",
+        "Last Name": "Campbell",
+        "UPI": "pcam471",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "bles848": {
+        "Timestamp": "28/02/2022 17:54:19",
+        "First Name": "Belinda",
+        "Last Name": "Lesmana",
+        "UPI": "bles848",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "fwan269": {
+        "Timestamp": "28/02/2022 17:55:44",
+        "First Name": "Fangping",
+        "Last Name": "Wang",
+        "UPI": "fwan269",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "yhua595": {
+        "Timestamp": "28/02/2022 17:55:50",
+        "First Name": "Elaine",
+        "Last Name": "Huang",
+        "UPI": "yhua595",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "wany735": {
+        "Timestamp": "28/02/2022 17:55:58",
+        "First Name": "Ashley",
+        "Last Name": "Wang",
+        "UPI": "wany735",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "emcc153": {
+        "Timestamp": "28/02/2022 18:07:03",
+        "First Name": "Emily",
+        "Last Name": "McClame",
+        "UPI": "emcc153",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "scol592": {
+        "Timestamp": "28/02/2022 18:16:17",
+        "First Name": "Shaun",
+        "Last Name": "Cole-Baker",
+        "UPI": "scol592",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "ecom665": {
+        "Timestamp": "28/02/2022 18:17:13",
+        "First Name": "Eliana",
+        "Last Name": "Competente",
+        "UPI": "ecom665",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "jcra210": {
+        "Timestamp": "28/02/2022 18:21:38",
+        "First Name": "Juliette",
+        "Last Name": "Crawford",
+        "UPI": "jcra210",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "mmat211": {
+        "Timestamp": "28/02/2022 18:26:42",
+        "First Name": "Mila",
+        "Last Name": "Matthews",
+        "UPI": "mmat211",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "sbos268": {
+        "Timestamp": "28/02/2022 18:31:30",
+        "First Name": "Sanne (said sun-a)",
+        "Last Name": "Bosman ",
+        "UPI": "sbos268",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "vzuo287": {
+        "Timestamp": "28/02/2022 18:37:49",
+        "First Name": "Veronica",
+        "Last Name": "Zuo",
+        "UPI": "vzuo287",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "mtra075": {
+        "Timestamp": "28/02/2022 18:53:37",
+        "First Name": "Tommy",
+        "Last Name": "Tran",
+        "UPI": "mtra075",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "rbha917": {
+        "Timestamp": "28/02/2022 19:05:24",
+        "First Name": "Roshni ",
+        "Last Name": "Bhatti",
+        "UPI": "rbha917",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "dsha306": {
+        "Timestamp": "28/02/2022 19:12:32",
+        "First Name": "Dania",
+        "Last Name": "Shafiq",
+        "UPI": "dsha306",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "nmat657": {
+        "Timestamp": "28/02/2022 19:59:12",
+        "First Name": "Nene",
+        "Last Name": "Matsuki",
+        "UPI": "nmat657",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "seas315": {
+        "Timestamp": "28/02/2022 20:22:00",
+        "First Name": "Sabina ",
+        "Last Name": "East",
+        "UPI": "seas315",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "mhoa018": {
+        "Timestamp": "28/02/2022 20:24:23",
+        "First Name": "Megan",
+        "Last Name": "Hoare",
+        "UPI": "mhoa018",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "Ntur248": {
+        "Timestamp": "28/02/2022 20:39:15",
+        "First Name": "Nikita",
+        "Last Name": "Turoa",
+        "UPI": "Ntur248",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "msta799": {
+        "Timestamp": "28/02/2022 21:09:25",
+        "First Name": "Maddy",
+        "Last Name": "Stanton",
+        "UPI": "msta799",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "apra413": {
+        "Timestamp": "28/02/2022 22:31:40",
+        "First Name": "Aiesha",
+        "Last Name": "Prakash",
+        "UPI": "apra413",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "tlau099": {
+        "Timestamp": "28/02/2022 22:39:53",
+        "First Name": "Tiffany",
+        "Last Name": "Lau",
+        "UPI": "tlau099",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "jpra449": {
+        "Timestamp": "01/03/2022 01:21:54",
+        "First Name": "Joshika",
+        "Last Name": "Prasad",
+        "UPI": "jpra449",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "asan655": {
+        "Timestamp": "01/03/2022 10:26:12",
+        "First Name": "Angelu",
+        "Last Name": "Santos",
+        "UPI": "asan655",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "tsir280": {
+        "Timestamp": "01/03/2022 16:18:18",
+        "First Name": "Tiara",
+        "Last Name": "Siregar",
+        "UPI": "tsir280",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "mlip814": {
+        "Timestamp": "01/03/2022 10:30:15",
+        "First Name": "Marrick",
+        "Last Name": "Lip",
+        "UPI": "mlip814",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "jmud755": {
+        "Timestamp": "01/03/2022 10:45:55",
+        "First Name": "Joti",
+        "Last Name": "Mudaliar ",
+        "UPI": "jmud755",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "gtal532": {
+        "Timestamp": "01/03/2022 10:56:10",
+        "First Name": "Giane",
+        "Last Name": "Talosig",
+        "UPI": "gtal532",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "wqiu237": {
+        "Timestamp": "01/03/2022 11:00:37",
+        "First Name": "Wayne",
+        "Last Name": "Qiu",
+        "UPI": "wqiu237",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "rmoo933": {
+        "Timestamp": "01/03/2022 11:19:49",
+        "First Name": "Rachel",
+        "Last Name": "Moon",
+        "UPI": "rmoo933",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "hcha460": {
+        "Timestamp": "01/03/2022 11:44:22",
+        "First Name": "Hanna",
+        "Last Name": "Chan",
+        "UPI": "hcha460",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "yzhu688": {
+        "Timestamp": "01/03/2022 12:48:54",
+        "First Name": "Angie",
+        "Last Name": "Zhu",
+        "UPI": "yzhu688",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "tlia653": {
+        "Timestamp": "01/03/2022 12:48:55",
+        "First Name": "Tina ",
+        "Last Name": "Liang",
+        "UPI": "tlia653",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "jvil373": {
+        "Timestamp": "01/03/2022 12:51:00",
+        "First Name": "Jessica",
+        "Last Name": "Villegas",
+        "UPI": "jvil373",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "cnew454": {
+        "Timestamp": "01/03/2022 13:19:19",
+        "First Name": "Connor",
+        "Last Name": "Newington ",
+        "UPI": "cnew454",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "enar333": {
+        "Timestamp": "01/03/2022 13:21:44",
+        "First Name": "Emma",
+        "Last Name": "Narasy",
+        "UPI": "enar333",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "lcol276": {
+        "Timestamp": "01/03/2022 13:22:56",
+        "First Name": "Krishi",
+        "Last Name": "Shah",
+        "UPI": "lcol276",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "zsue951": {
+        "Timestamp": "01/03/2022 13:49:36",
+        "First Name": "Zara",
+        "Last Name": "Sue",
+        "UPI": "zsue951",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "syou851": {
+        "Timestamp": "01/03/2022 13:49:38",
+        "First Name": "Sam",
+        "Last Name": "Young",
+        "UPI": "syou851",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "jbal547": {
+        "Timestamp": "01/03/2022 14:18:29",
+        "First Name": "Janani",
+        "Last Name": "Balasubramaniam",
+        "UPI": "jbal547",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "ktak410": {
+        "Timestamp": "01/03/2022 15:24:11",
+        "First Name": "Keita",
+        "Last Name": "Takahashi",
+        "UPI": "ktak410",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "scre877": {
+        "Timestamp": "01/03/2022 16:35:30",
+        "First Name": "Sophia",
+        "Last Name": "Creak",
+        "UPI": "scre877",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "ndev633": {
+        "Timestamp": "01/03/2022 17:00:15",
+        "First Name": "Navneet",
+        "Last Name": "Devgun",
+        "UPI": "ndev633",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "ggau682": {
+        "Timestamp": "01/03/2022 22:00:22",
+        "First Name": "Gauri",
+        "Last Name": "Arora",
+        "UPI": "ggau682",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "nire527": {
+        "Timestamp": "01/03/2022 18:49:20",
+        "First Name": "Nikita",
+        "Last Name": "Irene",
+        "UPI": "nire527",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "tkri137 (bank: 03-1399-0262727-000)": {
+        "Timestamp": "01/03/2022 18:50:45",
+        "First Name": "Trista",
+        "Last Name": "Krishnan",
+        "UPI": "tkri137 (bank: 03-1399-0262727-000)",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "jesp141": {
+        "Timestamp": "01/03/2022 18:56:12",
+        "First Name": "Jefritz",
+        "Last Name": "Espino",
+        "UPI": "jesp141",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "itak393": {
+        "Timestamp": "01/03/2022 20:36:48",
+        "First Name": "Isha",
+        "Last Name": "Takyar",
+        "UPI": "itak393",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "lwon570": {
+        "Timestamp": "01/03/2022 21:21:04",
+        "First Name": "Lee",
+        "Last Name": "Wong",
+        "UPI": "lwon570",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "hle735": {
+        "Timestamp": "01/03/2022 22:20:28",
+        "First Name": "Holly",
+        "Last Name": "Le",
+        "UPI": "hle735",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "ahua352": {
+        "Timestamp": "01/03/2022 22:21:29",
+        "First Name": "Amanda",
+        "Last Name": "Huang",
+        "UPI": "ahua352",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "vcui658": {
+        "Timestamp": "01/03/2022 22:27:00",
+        "First Name": "Vanessa",
+        "Last Name": "Cui",
+        "UPI": "vcui658",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "ejoe963": {
+        "Timestamp": "01/03/2022 22:58:08",
+        "First Name": "Emily",
+        "Last Name": "Joe",
+        "UPI": "ejoe963",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "wsha419": {
+        "Timestamp": "02/03/2022 01:57:25",
+        "First Name": "Wen",
+        "Last Name": "Shan",
+        "UPI": "wsha419",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "Aesc555": {
+        "Timestamp": "02/03/2022 12:27:02",
+        "First Name": "Aissey Viancea",
+        "Last Name": "Escasenas",
+        "UPI": "Aesc555",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "imat970": {
+        "Timestamp": "02/03/2022 18:41:08",
+        "First Name": "Isabella",
+        "Last Name": "Matthews",
+        "UPI": "imat970",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "ytsa227": {
+        "Timestamp": "02/03/2022 19:19:35",
+        "First Name": "Yuan",
+        "Last Name": "Tsai",
+        "UPI": "ytsa227",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "Shon178": {
+        "Timestamp": "02/03/2022 19:36:50",
+        "First Name": "Sounita",
+        "Last Name": "Hongsouvanh ",
+        "UPI": "Shon178",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "Slia742": {
+        "Timestamp": "02/03/2022 20:08:08",
+        "First Name": "Joyce",
+        "Last Name": "Liang",
+        "UPI": "Slia742",
+        "Returning member? ": "Yes",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "tsha812": {
+        "Timestamp": "02/03/2022 20:12:46",
+        "First Name": "Trisha",
+        "Last Name": "Shahane",
+        "UPI": "tsha812",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "jper451": {
+        "Timestamp": "02/03/2022 20:48:27",
+        "First Name": "Jade",
+        "Last Name": "Perry",
+        "UPI": "jper451",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "cleu918": {
+        "Timestamp": "02/03/2022 21:39:41",
+        "First Name": "Cindy",
+        "Last Name": "Leung",
+        "UPI": "cleu918",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "spra951": {
+        "Timestamp": "03/03/2022 11:16:21",
+        "First Name": "Sakshi",
+        "Last Name": "Prasad",
+        "UPI": "spra951",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "cboy574": {
+        "Timestamp": "03/03/2022 14:16:35",
+        "First Name": "Camerin",
+        "Last Name": "Boyes",
+        "UPI": "cboy574",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "kwah139": {
+        "Timestamp": "03/03/2022 14:37:16",
+        "First Name": "Khalila",
+        "Last Name": "Wahyudi",
+        "UPI": "kwah139",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "gmac188": {
+        "Timestamp": "03/03/2022 16:37:39",
+        "First Name": "Georgia",
+        "Last Name": "Macdonald",
+        "UPI": "gmac188",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "Ddar261": {
+        "Timestamp": "03/03/2022 20:21:32",
+        "First Name": "Delna",
+        "Last Name": "Daruwala",
+        "UPI": "Ddar261",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "lcha570": {
+        "Timestamp": "04/03/2022 20:21:32",
+        "First Name": "Sandra",
+        "Last Name": "Chan",
+        "UPI": "lcha570",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "shud653": {
+        "Timestamp": "05/03/2022 20:21:32",
+        "First Name": "Sam",
+        "Last Name": "Huddart ",
+        "UPI": "shud653",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "Clew715": {
+        "Timestamp": "06/03/2022 20:21:32",
+        "First Name": "Charlotte",
+        "Last Name": "Lewis",
+        "UPI": "Clew715",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "yshe735": {
+        "Timestamp": "07/03/2022 20:21:32",
+        "First Name": "Yuwei",
+        "Last Name": "Shen",
+        "UPI": "yshe735",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "sswa356": {
+        "Timestamp": "08/03/2022 20:21:32",
+        "First Name": "Suvarna",
+        "Last Name": "Swaraj",
+        "UPI": "sswa356",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "mrob303": {
+        "Timestamp": "09/03/2022 20:21:32",
+        "First Name": "Max",
+        "Last Name": "Robinson",
+        "UPI": "mrob303",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "bgab537": {
+        "Timestamp": "10/03/2022 20:21:32",
+        "First Name": "Bea",
+        "Last Name": "Gabon",
+        "UPI": "bgab537",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "mmar250": {
+        "Timestamp": "11/03/2022 20:21:32",
+        "First Name": "Micole",
+        "Last Name": "Marquez",
+        "UPI": "mmar250",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "hker616": {
+        "Timestamp": "12/03/2022 20:21:32",
+        "First Name": "Hazel",
+        "Last Name": "Kerr",
+        "UPI": "hker616",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "xma157": {
+        "Timestamp": "13/03/2022 20:21:32",
+        "First Name": "Lucy",
+        "Last Name": "Ma",
+        "UPI": "xma157",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "kros799": {
+        "Timestamp": "14/03/2022 16:51:44",
+        "First Name": "Kingston ",
+        "Last Name": "Ross",
+        "UPI": "kros799",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "eren152": {
+        "Timestamp": "14/03/2022 20:21:32",
+        "First Name": "Emily",
+        "Last Name": "Ren",
+        "UPI": "eren152",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "cche547 ": {
+        "Timestamp": "15/03/2022 15:20:55",
+        "First Name": "Milo",
+        "Last Name": "Cheung ",
+        "UPI": "cche547 ",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "jjug792": {
+        "Timestamp": "15/03/2022 15:35:09",
+        "First Name": "Juan Enrique",
+        "Last Name": "Jugo",
+        "UPI": "jjug792",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "talb187": {
+        "Timestamp": "15/03/2022 19:19:55",
+        "First Name": "Tania ",
+        "Last Name": "bayat",
+        "UPI": "talb187",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "ylee480": {
+        "Timestamp": "15/03/2022 20:14:43",
+        "First Name": "Esther",
+        "Last Name": "Lee",
+        "UPI": "ylee480",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "shut481": {
+        "Timestamp": "15/03/2022 20:21:32",
+        "First Name": "Sophie",
+        "Last Name": "Hutchinson",
+        "UPI": "shut481",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "Kmay577": {
+        "Timestamp": "15/03/2022 21:09:04",
+        "First Name": "Karepa",
+        "Last Name": "Maynard",
+        "UPI": "Kmay577",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "jcao402": {
+        "Timestamp": "15/03/2022 23:35:54",
+        "First Name": "Jennifer",
+        "Last Name": "Cao",
+        "UPI": "jcao402",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "clee843": {
+        "Timestamp": "16/03/2022 20:21:32",
+        "First Name": "Chloe ",
+        "Last Name": "Lee",
+        "UPI": "clee843",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "ddon632": {
+        "Timestamp": "17/03/2022 15:03:30",
+        "First Name": "Doris ",
+        "Last Name": "Dong",
+        "UPI": "ddon632",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "jcom027": {
+        "Timestamp": "18/03/2022 11:28:20",
+        "First Name": "Josh",
+        "Last Name": "Commons",
+        "UPI": "jcom027",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "jehc787": {
+        "Timestamp": "18/03/2022 20:21:32",
+        "First Name": "Jessie",
+        "Last Name": "Chen",
+        "UPI": "jehc787",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "pset965": {
+        "Timestamp": "19/03/2022 20:21:32",
+        "First Name": "Prashanti",
+        "Last Name": "Seth",
+        "UPI": "pset965",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "gmac159": {
+        "Timestamp": "21/03/2022 18:05:32",
+        "First Name": "Grace",
+        "Last Name": "MacMahon",
+        "UPI": "gmac159",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "jrom056": {
+        "Timestamp": "21/03/2022 20:21:32",
+        "First Name": "Basti",
+        "Last Name": "Romano",
+        "UPI": "jrom056",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "ncoo680": {
+        "Timestamp": "22/03/2022 20:21:32",
+        "First Name": "Narissa",
+        "Last Name": "Cook",
+        "UPI": "ncoo680",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "cebr029": {
+        "Timestamp": "23/03/2022 20:21:32",
+        "First Name": "Claire",
+        "Last Name": "Ebreo",
+        "UPI": "cebr029",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "adin525": {
+        "Timestamp": "25/03/2022 20:21:32",
+        "First Name": "Annabelle",
+        "Last Name": "Ding",
+        "UPI": "adin525",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "Oguo822": {
+        "Timestamp": "26/03/2022 20:21:32",
+        "First Name": "Oscar ",
+        "Last Name": "Guo",
+        "UPI": "Oguo822",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "nino850": {
+        "Timestamp": "27/03/2022 20:21:32",
+        "First Name": "Nodoka",
+        "Last Name": "Inoue",
+        "UPI": "nino850",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "amar589": {
+        "Timestamp": "29/03/2022 20:21:32",
+        "First Name": "Ashley",
+        "Last Name": "Mar",
+        "UPI": "amar589",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "Rsha398": {
+        "Timestamp": "30/03/2022 20:21:32",
+        "First Name": "Rubab",
+        "Last Name": "Shah",
+        "UPI": "Rsha398",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "azac627": {
+        "Timestamp": "31/03/2022 20:21:32",
+        "First Name": "Aruna",
+        "Last Name": "Zachariah ",
+        "UPI": "azac627",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "mten922": {
+        "Timestamp": "01/04/2022 20:21:32",
+        "First Name": "Mac",
+        "Last Name": "Teng",
+        "UPI": "mten922",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "esan563": {
+        "Timestamp": "02/04/2022 20:21:32",
+        "First Name": " Yana",
+        "Last Name": "Sanvictores",
+        "UPI": "esan563",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "tkim193": {
+        "Timestamp": "03/04/2022 20:21:32",
+        "First Name": "Chloe",
+        "Last Name": "Kim",
+        "UPI": "tkim193",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "mada174": {
+        "Timestamp": "04/04/2022 20:21:32",
+        "First Name": "Atten",
+        "Last Name": "Adams",
+        "UPI": "mada174",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "ssud216@aucklanduni.ac.nz ": {
+        "Timestamp": "05/04/2022 20:21:32",
+        "First Name": "(Mook) Supitcha",
+        "Last Name": "Sudtipunyo ",
+        "UPI": "ssud216@aucklanduni.ac.nz ",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "Fabo411": {
+        "Timestamp": "06/04/2022 20:21:32",
+        "First Name": "Faiza",
+        "Last Name": "Aboobacker",
+        "UPI": "Fabo411",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "kpar655": {
+        "Timestamp": "08/04/2022 20:21:32",
+        "First Name": "Kyuwon ",
+        "Last Name": "Park ",
+        "UPI": "kpar655",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "ahas382": {
+        "Timestamp": "10/04/2022 20:21:32",
+        "First Name": "Arsheen",
+        "Last Name": "Hasolkar ",
+        "UPI": "ahas382",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "jjia894": {
+        "Timestamp": "11/04/2022 20:21:32",
+        "First Name": "Joanna",
+        "Last Name": "Jiang",
+        "UPI": "jjia894",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "bcok080": {
+        "Timestamp": "12/04/2022 20:21:32",
+        "First Name": "Brenda ",
+        "Last Name": "Cokorudy ",
+        "UPI": "bcok080",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "yrab895": {
+        "Timestamp": "14/04/2022 20:21:32",
+        "First Name": "Yashka",
+        "Last Name": "Rabichand",
+        "UPI": "yrab895",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "syoo188": {
+        "Timestamp": "20/04/2022 20:21:32",
+        "First Name": "Peter",
+        "Last Name": "Yoon",
+        "UPI": "syoo188",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "bmur430": {
+        "Timestamp": "22/04/2022 20:21:32",
+        "First Name": "Ben",
+        "Last Name": "Murray",
+        "UPI": "bmur430",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "Mwai122": {
+        "Timestamp": "21/03/2022 23:21:37",
+        "First Name": "Matthew",
+        "Last Name": "Waiariki",
+        "UPI": "Mwai122",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "LSO199": {
+        "Timestamp": "22/03/2022 01:07:31",
+        "First Name": "Andrea",
+        "Last Name": "So",
+        "UPI": "LSO199",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "etho184": {
+        "Timestamp": "22/03/2022 13:19:24",
+        "First Name": "Ella",
+        "Last Name": "Thorowgood",
+        "UPI": "etho184",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "Lkun464": {
+        "Timestamp": "22/03/2022 22:37:59",
+        "First Name": "Lenna",
+        "Last Name": "Kunisawa",
+        "UPI": "Lkun464",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "skom972": {
+        "Timestamp": "27/03/2022 19:11:25",
+        "First Name": "Simran",
+        "Last Name": "Komalan",
+        "UPI": "skom972",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "snei830": {
+        "Timestamp": "06/04/2022 13:38:59",
+        "First Name": "Stephanie",
+        "Last Name": "Neilson",
+        "UPI": "snei830",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "dcha635": {
+        "Timestamp": "06/04/2022 20:14:05",
+        "First Name": "Daniel",
+        "Last Name": "Cha",
+        "UPI": "dcha635",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "spur833": {
+        "Timestamp": "10/04/2022 08:37:24",
+        "First Name": "Swati",
+        "Last Name": "Puri",
+        "UPI": "spur833",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "lzub675 ": {
+        "Timestamp": "13/04/2022 12:01:45",
+        "First Name": "Layba",
+        "Last Name": "Zubair ",
+        "UPI": "lzub675 ",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "twri464": {
+        "Timestamp": "14/04/2022 21:13:54",
+        "First Name": "Terence",
+        "Last Name": "Wright",
+        "UPI": "twri464",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes ",
+        "App_Eligible": "y"
+    },
+    "augn576 ": {
+        "Timestamp": "01/03/2022 14:47:33",
+        "First Name": "Anh",
+        "Last Name": "Nguyen",
+        "UPI": "augn576 ",
+        "Returning member? ": "No",
+        "Amount to pay": "8",
+        "Paid?": "Yes (paid $5 not $8)",
+        "App_Eligible": "y"
+    }
+}

--- a/firebaseSetup.ts
+++ b/firebaseSetup.ts
@@ -13,5 +13,3 @@ const firebaseConfig = {
 
 firebase.initializeApp(firebaseConfig)
 export default firebase
-
-// export const auth = firebase.auth();


### PR DESCRIPTION
Added eligibility checks for registering new users (i.e. checking if user has paid for membership by checking through a JSON file of members)

**Issue:**
No checks made with actual member data when registering new users to the app - anyone could register.

**Solution:**
Adding eligibility checks using real membership data

**Risk:**
Currently the real membership data is stored in a JSON file on this repo, so might be a security concern but only the UPI is sensitive information, the rest of the data is not too personal to the members.

**Reviewed By:**
